### PR TITLE
fix(seo): redirect www, canonicalize index.md, noindex agent files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+const HOME_URL = 'https://aicommit.app/';
+const AGENT_RESOURCE_NO_INDEX_HEADERS = [
+  { key: 'X-Robots-Tag', value: 'noindex, follow' },
+];
 
 const nextConfig = {
   reactStrictMode: true,
@@ -15,6 +19,21 @@ const nextConfig = {
     // Tree-shake icon packages so only imported icons are bundled.
     optimizePackageImports: ['lucide-react', '@icons-pack/react-simple-icons'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'www.aicommit.app',
+          },
+        ],
+        destination: `${HOME_URL}:path*`,
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {
@@ -29,6 +48,27 @@ const nextConfig = {
             ].join(', '),
           },
         ],
+      },
+      {
+        source: '/index.md',
+        headers: [
+          {
+            key: 'Link',
+            value: `<${HOME_URL}>; rel="canonical"`,
+          },
+        ],
+      },
+      {
+        source: '/llms.txt',
+        headers: AGENT_RESOURCE_NO_INDEX_HEADERS,
+      },
+      {
+        source: '/llms-full.txt',
+        headers: AGENT_RESOURCE_NO_INDEX_HEADERS,
+      },
+      {
+        source: '/.well-known/ai-agent.json',
+        headers: AGENT_RESOURCE_NO_INDEX_HEADERS,
       },
       {
         source: '/_next/static/:path*',

--- a/tests/seo-output.test.mjs
+++ b/tests/seo-output.test.mjs
@@ -126,6 +126,48 @@ test('root response advertises agent-readable alternates with Link headers', asy
   assert.match(linkHeaders, /<https:\/\/aicommit\.app\/\.well-known\/ai-agent\.json>;\s*rel="service-desc"/);
 });
 
+test('canonical host redirects and non-page agent resources are not search-index candidates', async () => {
+  const { default: nextConfig } = await import(pathToFileURL(path.join(root, 'next.config.js')).href);
+  const redirects = await nextConfig.redirects();
+  const headers = await nextConfig.headers();
+
+  assert.deepEqual(redirects, [
+    {
+      source: '/:path*',
+      has: [
+        {
+          type: 'host',
+          value: 'www.aicommit.app',
+        },
+      ],
+      destination: 'https://aicommit.app/:path*',
+      permanent: true,
+    },
+  ]);
+
+  const indexMarkdownHeaders = headers.find((route) => route.source === '/index.md')?.headers ?? [];
+  assert.ok(
+    indexMarkdownHeaders.some(
+      (header) =>
+        header.key === 'Link' &&
+        header.value === '<https://aicommit.app/>; rel="canonical"'
+    ),
+    'markdown snapshot should point Google at the canonical homepage'
+  );
+
+  for (const source of ['/llms.txt', '/llms-full.txt', '/.well-known/ai-agent.json']) {
+    const routeHeaders = headers.find((route) => route.source === source)?.headers ?? [];
+    assert.ok(
+      routeHeaders.some(
+        (header) =>
+          header.key === 'X-Robots-Tag' &&
+          header.value === 'noindex, follow'
+      ),
+      `${source} should be crawlable but explicitly excluded from search indexing`
+    );
+  }
+});
+
 test('screenshot source assets are webp and kept compact', () => {
   const files = readdirSync(screenshotsDir).sort();
   const totalBytes = files.reduce((sum, file) => sum + statSync(path.join(screenshotsDir, file)).size, 0);

--- a/tests/seo-output.test.mjs
+++ b/tests/seo-output.test.mjs
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const root = '/Users/rosu/Coding/AI-COMMIT/LandingPage';
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(testDir, '..');
 const buildMarker = path.join(root, '.next', 'server', 'pages', 'index.html');
 const robotsPath = path.join(root, 'public', 'robots.txt');
 const sitemapPath = path.join(root, 'public', 'sitemap.xml');


### PR DESCRIPTION
## Summary

Reduce non-page search-index candidates flagged in the 2026-05-24 Google Search Console export (1 indexed / 26 not indexed for `https://aicommit.app/`).

- **`www` -> apex permanent redirect.** Adds a Next host-conditioned redirect: any request reaching the app with `Host: www.aicommit.app` is 308'd to the matching path on `https://aicommit.app/`.
- **`/index.md` canonical Link header.** `/index.md` is a Markdown rendering of the homepage. Adds `Link: <https://aicommit.app/>; rel="canonical"` so Google consolidates ranking signals into the canonical homepage rather than treating the snapshot as a separate search-index candidate.
- **`X-Robots-Tag: noindex, follow` on agent-readable non-page resources.** Applies to `/llms.txt`, `/llms-full.txt`, and `/.well-known/ai-agent.json`. These remain crawlable for AI/agent discovery (still linked from the homepage and from `Link` headers on `/`), but are no longer eligible as independent Google search results.

The canonical homepage at `https://aicommit.app/` continues to be indexable; static media, fonts, and screenshot caching are untouched.

## Test plan

- [x] `git diff --check` — no whitespace issues
- [x] `npm run lint` — `✔ No ESLint warnings or errors`
- [x] `npm run test:seo` — 6/6 passing, including a new shape test that asserts the exact `redirects()` rule and the `/index.md` canonical + three `X-Robots-Tag` headers
- [x] Local `npm run start` probe (coordinator-captured): `Host: www.aicommit.app` -> 308 to apex; `/index.md` returns the canonical Link header; the three agent resources return `X-Robots-Tag: noindex, follow`
- [ ] Post-deploy: `curl -I https://aicommit.app/index.md`, `…/llms.txt`, `…/llms-full.txt`, `…/.well-known/ai-agent.json` show the new headers
- [ ] Post-deploy: re-validate the affected Search Console reasons (`Alternate page with proper canonical tag`, `Duplicate without user-selected canonical`)

## External follow-up (not in this PR)

`https://www.aicommit.app/` currently returns HTTP 404 with `x-github-request-id`, meaning the hostname terminates at GitHub Pages and never reaches the Cloudflare Pages Worker. The Next-level redirect in this PR cannot fire until `www.aicommit.app` is either bound to the same Cloudflare Pages project, redirected at the Cloudflare edge before any origin, or removed from the conflicting GitHub Pages site.