### PR TITLE
docs: Cloudflare Pages README + address PR #3 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,60 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# AICommit — Landing Page
 
-## Getting Started
+Marketing site for **[AICommit](https://aicommit.app)** — a JetBrains IDE plugin that generates
+git commit messages from your staged diff. Live at **https://aicommit.app**.
 
-First, run the development server:
+Built with **Next.js 15** (Pages Router) + TypeScript + **Tailwind CSS**, with `framer-motion`
+for animation and self-hosted **Zed Sans / Zed Mono** fonts via `next/font/local`. Deployed on
+**Cloudflare Pages**.
+
+## Getting started
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
+npm install
+npm run dev          # http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Edit the home page from `pages/index.tsx`; the sections live in `components/landing/*`.
+Node ≥ 18 (see `.node-version`).
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+### Scripts
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+| Script | What it does |
+| --- | --- |
+| `npm run dev` | Local dev server |
+| `npm run build` | Production build |
+| `npm run lint` | ESLint (`next/core-web-vitals`) |
+| `npm run test:seo` | Builds, then asserts the SEO output — SSR metadata, JSON-LD, `robots.txt`, `sitemap.xml`, the agent-readable files, and the `next.config.js` headers/redirects |
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+## Deployment — Cloudflare Pages
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+Deployed to **Cloudflare Pages** via its GitHub integration: every push to `main` triggers a
+build on Cloudflare's side. (The build/deploy check you see on commits and PRs is the Cloudflare
+Pages deployment — there are no GitHub Actions workflows in this repo.)
 
-## Learn More
+The build runs through **[`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages)**,
+which adapts the Next.js output to the Pages runtime and translates `next.config.js` `redirects()`
+and `headers()` into Cloudflare routing — so the **www → apex 301**, the `X-Robots-Tag: noindex`
+on the agent files, and the long-lived cache headers all originate from `next.config.js`.
 
-To learn more about Next.js, take a look at the following resources:
+**Cloudflare Pages project settings:**
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+| Setting | Value |
+| --- | --- |
+| Build command | `npx @cloudflare/next-on-pages` |
+| Build output directory | `.vercel/output/static` |
+| Compatibility flags | `nodejs_compat` |
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+Domains: `aicommit.app` (apex) is the Pages custom domain; `www.aicommit.app` 301-redirects to it.
 
-## Deploy on Vercel
+## Project layout
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+| Path | Purpose |
+| --- | --- |
+| `pages/index.tsx` | Home page |
+| `pages/404.tsx` | Branded git-terminal 404 (see `components/notfound/README.md`) |
+| `components/landing/` | Page sections (`Hero`, `Features`, `Reviews`, …) |
+| `components/ui/` | Shared UI bits |
+| `lib/seo.ts` | Titles, description, FAQ, and the JSON-LD structured data |
+| `public/` | `robots.txt`, `sitemap.xml`, OG image, fonts, and agent-readable resources (`llms.txt`, `llms-full.txt`, `index.md`, `.well-known/ai-agent.json`) |
+| `tests/seo-output.test.mjs` | Guards the SEO / structured-data output |

--- a/components/notfound/GitTerminal.tsx
+++ b/components/notfound/GitTerminal.tsx
@@ -6,7 +6,8 @@
 // answers with `fatal: pathspec ... did not match`, prints an ASCII "404" + a broken
 // commit graph, then drops you at a live, interactive prompt (help / ls / git status /
 // git log / history with ↑↓ / Tab-complete). The same command handler powers the
-// clickable recovery chips, so typing and clicking share one path.
+// `cd ~` / `help` recovery chips, so typing and clicking share one path; the Marketplace
+// chip is a plain external link.
 //
 // Zero new dependencies: pure React + DOM + setTimeout. Reuses framer-motion's
 // useReducedMotion (already bundled), Zed Mono (font-mono) and .cursor-blink.
@@ -98,7 +99,7 @@ function RecoveryChips() {
       <button type="button" className={`${chip} border-brand/40 bg-brand/[0.08] text-gray-100 hover:border-brand hover:bg-brand/[0.16]`} onClick={() => chipRun?.('cd ~')}>
         <A>cd ~</A><D>→</D><D>go home</D>
       </button>
-      <a href={MARKETPLACE_URL} target="_blank" rel="noopener noreferrer" className={`${chip} border-brand/40 bg-brand/[0.08] text-gray-100 hover:border-brand hover:bg-brand/[0.16]`} onClick={(e) => { e.preventDefault(); chipRun?.('git remote -v'); }}>
+      <a href={MARKETPLACE_URL} target="_blank" rel="noopener noreferrer" className={`${chip} border-brand/40 bg-brand/[0.08] text-gray-100 hover:border-brand hover:bg-brand/[0.16]`}>
         <A>git remote -v</A><D>→</D><D>open Marketplace</D>
       </a>
       <button type="button" className={`${chip} border-white/15 bg-white/[0.03] text-gray-100 hover:border-white/30 hover:bg-white/[0.06]`} onClick={() => chipRun?.('help')}>
@@ -149,7 +150,8 @@ export default function GitTerminal() {
           <><A>origin</A>  {MARKETPLACE_URL} <D>(push)</D></>,
           <D>Opening JetBrains Marketplace…</D>,
         );
-        window.setTimeout(() => window.open(MARKETPLACE_URL, '_blank', 'noopener,noreferrer'), 500);
+        // Open synchronously, inside the keydown/click gesture, or popup blockers eat it.
+        window.open(MARKETPLACE_URL, '_blank', 'noopener,noreferrer');
         return;
       }
 

--- a/components/notfound/README.md
+++ b/components/notfound/README.md
@@ -55,8 +55,10 @@ that process is the `concept-shootout` Claude skill.
   Add the command to `TAB_OPTIONS` if it should Tab-complete.
 - **Change the boot script:** edit `bootScript(path)` — a list of `{ kind: 'type' | 'print' }`
   steps. `type` animates a command char-by-char; `print` reveals a line after `delay` ms.
-- **Recovery chips:** `RecoveryChips` (rendered inline in the scrollback). They route through
-  the same `run()` handler as typed input via the module-level `chipRun`.
+- **Recovery chips:** `RecoveryChips` (rendered inline in the scrollback). The `cd ~` and `help`
+  chips route through the same `run()` handler as typed input (via the module-level `chipRun`);
+  the Marketplace chip is a plain external `<a>` link so it opens natively (real link semantics,
+  no popup-blocker issues).
 
 ## Verify after changes
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,7 +9,8 @@ export const DOWNLOAD_COUNT = 22490;
 export const MARKETPLACE_RATING = 4.1;
 export const MARKETPLACE_RATING_COUNT = 15;
 
-// Bump when the page's substantive content changes. Feeds JSON-LD dateModified
-// and the "Last updated" lines in the agent files (llms.txt, llms-full.txt,
-// index.md, ai-agent.json).
+// Bump when the page's substantive content changes. Feeds the JSON-LD
+// `dateModified`. The "Last updated" lines in the agent files (llms.txt,
+// llms-full.txt, index.md, ai-agent.json) are hand-maintained, not derived
+// from this constant — bump them to match when content changes.
 export const LAST_UPDATED = '2026-06-14';

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -103,23 +103,36 @@ export const homeStructuredData = {
         `${SITE_URL}/screenshots/s_1_commit_panel.webp`,
         `${SITE_URL}/screenshots/s_2_template.webp`,
       ],
-      offers: {
-        '@type': 'Offer',
-        price: '1.00',
-        priceCurrency: 'USD',
-        availability: 'https://schema.org/InStock',
-        url: MARKETPLACE_URL,
-        priceSpecification: {
-          '@type': 'UnitPriceSpecification',
+      offers: [
+        {
+          '@type': 'Offer',
+          name: 'Personal',
           price: '1.00',
           priceCurrency: 'USD',
-          referenceQuantity: {
-            '@type': 'QuantitativeValue',
-            value: 1,
-            unitCode: 'MON',
+          availability: 'https://schema.org/InStock',
+          url: MARKETPLACE_URL,
+          priceSpecification: {
+            '@type': 'UnitPriceSpecification',
+            price: '1.00',
+            priceCurrency: 'USD',
+            referenceQuantity: { '@type': 'QuantitativeValue', value: 1, unitCode: 'MON' },
           },
         },
-      },
+        {
+          '@type': 'Offer',
+          name: 'Commercial',
+          price: '3.00',
+          priceCurrency: 'USD',
+          availability: 'https://schema.org/InStock',
+          url: MARKETPLACE_URL,
+          priceSpecification: {
+            '@type': 'UnitPriceSpecification',
+            price: '3.00',
+            priceCurrency: 'USD',
+            referenceQuantity: { '@type': 'QuantitativeValue', value: 1, unitCode: 'MON' },
+          },
+        },
+      ],
       aggregateRating: {
         '@type': 'AggregateRating',
         ratingValue: MARKETPLACE_RATING,

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,6 @@ const AGENT_RESOURCE_NO_INDEX_HEADERS = [
 const nextConfig = {
   reactStrictMode: true,
   compress: true,
-  output: 'standalone',
   // Keep Next.js scoped to this project instead of the parent dir to avoid
   // dev-server restarts and hot-update 404s when other lockfiles exist.
   outputFileTracingRoot: __dirname,


### PR DESCRIPTION
Follow-up to #3. Verified: `tsc` clean · ESLint clean · `npm run test:seo` 6/6.

## `docs` — README for Cloudflare Pages
The root `README.md` was untouched create-next-app boilerplate. Rewrote it to describe the actual project and the **Cloudflare Pages** deployment (`@cloudflare/next-on-pages`, the Pages build settings, www→apex), and removed the now-wrong bits (Deploy-on-Vercel, a non-existent `/api/hello` route, "Inter font" → it self-hosts Zed). Also dropped `output: 'standalone'` from `next.config.js` — a Node self-hosting option that next-on-pages doesn't use (confirmed: build no longer emits `.next/standalone`).

## `fix` — PR #3 review feedback
Addresses the 4 Copilot review comments:

| Comment | Action |
| --- | --- |
| `window.open()` inside `setTimeout` → popup-blocked | ✅ Open the Marketplace URL **synchronously** inside the gesture |
| `<a>` chip that always `preventDefault()`s | ✅ Kept it an `<a>` (it's a real external link) but **removed the hijack** so it opens natively — better than converting to a button (preserves middle-click / copy-link / no-JS) |
| `LAST_UPDATED` comment misleading | ✅ Reworded — agent-file dates are hand-maintained, not derived from the constant |
| `offers` only had $1 | ✅ Publish **both** Personal ($1/mo) and Commercial ($3/mo) offers |

No behavior change to the homepage; the 404 terminal recovers identically (the Marketplace chip now opens reliably even with a popup blocker).