### PR TITLE
fix(ui): design-vocabulary audit — a11y fixes, type polish, tokens

### DIFF
--- a/components/landing/CompatibilityFaq.tsx
+++ b/components/landing/CompatibilityFaq.tsx
@@ -23,10 +23,10 @@ export const CompatibilityFaq = () => {
           <p className="text-xs font-mono uppercase tracking-[0.28em] text-brand/70 mb-3">
             Compatibility & onboarding
           </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight">
+          <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight text-balance">
             What developers ask before installing
           </h2>
-          <p className="text-gray-400 text-base md:text-lg mt-4 leading-relaxed">
+          <p className="text-gray-400 text-base md:text-lg mt-4 leading-relaxed text-pretty">
             The essentials for JetBrains compatibility, model support, privacy, local-only
             workflows, onboarding, and current Marketplace licensing.
           </p>
@@ -42,7 +42,7 @@ export const CompatibilityFaq = () => {
                 transition: { ...springBase, delay: index * 0.06 },
                 viewport: { once: true, margin: '-40px' },
               } : {})}
-              className="rounded-2xl border border-white/10 bg-white/4 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+              className="surface-card p-6"
             >
               <h3 className="text-lg font-semibold text-white tracking-tight">
                 {item.question}

--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -93,7 +93,7 @@ export const Features = () => {
           <p className="text-xs font-mono uppercase tracking-[0.28em] text-brand/70 mb-3">
             Why developers choose AICommit
           </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight">
+          <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight text-balance">
             AI commit messages, native to your JetBrains workflow
           </h2>
         </m.div>
@@ -141,7 +141,7 @@ export const Features = () => {
                           </m.div>
                         ))}
                       </div>
-                      <p className="text-center text-xs text-gray-600 mt-3">+ custom API endpoints</p>
+                      <p className="text-center text-xs text-gray-400 mt-3">+ custom API endpoints</p>
                     </div>
                   ) : (
                     <div className="relative w-full max-w-[280px] aspect-square flex items-center justify-center">
@@ -166,7 +166,7 @@ export const Features = () => {
                   <h3 className="text-2xl md:text-3xl font-bold text-white mb-4 tracking-tight">
                     {feature.title}
                   </h3>
-                  <p className="text-gray-400 leading-relaxed text-base md:text-lg">
+                  <p className="text-gray-400 leading-relaxed text-base md:text-lg text-pretty">
                     {feature.description}
                   </p>
                 </div>

--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -47,12 +47,10 @@ export const FinalCTA = () => {
                   Free trial on Marketplace
                 </m.div>
 
-                <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight mb-3">
-                  Stop writing commit
-                  <br />
-                  messages manually.
+                <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight mb-3 text-balance">
+                  Stop writing commit messages manually.
                 </h2>
-                <p className="text-gray-400 text-base max-w-md">
+                <p className="text-gray-400 text-base max-w-md text-pretty">
                   <AnimatedCounter
                     value={DOWNLOAD_COUNT}
                     format={(n) => n.toLocaleString() + '+'}

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { m, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { HelpCircle, Bug, FileText, ChevronRight, Menu, X } from 'lucide-react';
@@ -20,15 +20,51 @@ const externalLinks = [
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const shouldReduceMotion = useReducedMotion();
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
 
-  // Close on Escape key
+  // Trap focus inside the open mobile drawer: Escape closes, Tab cycles within.
   useEffect(() => {
     if (!isMenuOpen) return;
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsMenuOpen(false);
+      if (e.key === 'Escape') {
+        setIsMenuOpen(false);
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const root = drawerRef.current;
+      if (!root) return;
+      const focusables = root.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
+
     window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    // Move focus into the drawer once it has mounted.
+    const raf = requestAnimationFrame(() => {
+      drawerRef.current?.querySelector<HTMLElement>('a[href], button')?.focus();
+    });
+
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      cancelAnimationFrame(raf);
+    };
+  }, [isMenuOpen]);
+
+  // Return focus to the toggle button when the drawer closes.
+  useEffect(() => {
+    if (wasOpen.current && !isMenuOpen) toggleRef.current?.focus();
+    wasOpen.current = isMenuOpen;
   }, [isMenuOpen]);
 
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
@@ -47,7 +83,7 @@ export const Header = () => {
       <div className="container mx-auto px-6 h-16 flex justify-between items-center">
 
         {/* Left — Logo + name */}
-        <a href="#" className="flex items-center space-x-3" onClick={(e) => { e.preventDefault(); window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
+        <a href="#" className="flex items-center gap-3" onClick={(e) => { e.preventDefault(); window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
           <Image
             src="/favicon.svg"
             alt="AICommit Logo"
@@ -87,7 +123,8 @@ export const Header = () => {
 
         {/* Mobile hamburger */}
         <button
-          className="md:hidden p-2 text-gray-400 hover:text-white transition-colors"
+          ref={toggleRef}
+          className="md:hidden p-3 -mr-1 text-gray-400 hover:text-white transition-colors"
           aria-label="Toggle navigation"
           aria-expanded={isMenuOpen}
           aria-controls="mobile-nav"
@@ -101,12 +138,13 @@ export const Header = () => {
       <AnimatePresence>
         {isMenuOpen && (
           <m.div
+            ref={drawerRef}
             id="mobile-nav"
             className="md:hidden absolute top-16 left-0 right-0 z-40 border-b border-white/10 bg-[#21252f]/95 backdrop-blur-md"
             initial={shouldReduceMotion ? {} : { opacity: 0, y: -8 }}
-            animate={shouldReduceMotion ? {} : { opacity: 1, y: 0 }}
-            exit={shouldReduceMotion ? {} : { opacity: 0, y: -8 }}
-            transition={{ duration: 0.18 }}
+            // ease-out entering, ease-in leaving (enter vs exit asymmetry)
+            animate={shouldReduceMotion ? {} : { opacity: 1, y: 0, transition: { duration: 0.18, ease: [0, 0, 0.2, 1] } }}
+            exit={shouldReduceMotion ? {} : { opacity: 0, y: -8, transition: { duration: 0.15, ease: [0.4, 0, 1, 1] } }}
           >
             <div className="container mx-auto px-6 py-4 flex flex-col gap-3">
               {navLinks.map(({ label, href, external }) => (

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -72,7 +72,7 @@ export const Header = () => {
       e.preventDefault();
       const el = document.querySelector(href);
       if (el) {
-        el.scrollIntoView({ behavior: 'smooth' });
+        el.scrollIntoView({ behavior: shouldReduceMotion ? 'auto' : 'smooth' });
         setIsMenuOpen(false);
       }
     }
@@ -83,7 +83,7 @@ export const Header = () => {
       <div className="container mx-auto px-6 h-16 flex justify-between items-center">
 
         {/* Left — Logo + name */}
-        <a href="#" className="flex items-center gap-3" onClick={(e) => { e.preventDefault(); window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
+        <a href="#" className="flex items-center gap-3" onClick={(e) => { e.preventDefault(); window.scrollTo({ top: 0, behavior: shouldReduceMotion ? 'auto' : 'smooth' }); }}>
           <Image
             src="/favicon.svg"
             alt="AICommit Logo"

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -37,17 +37,14 @@ export const Hero = () => {
               <p className="text-xs font-mono uppercase tracking-[0.32em] text-brand/70 mb-4">
                 JetBrains Marketplace plugin
               </p>
-              <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-white leading-[1.08] mb-6">
-                AI commit message
-                <br />
-                generator for
-                <br />
-                <span className="text-brand">JetBrains IDEs</span>
+              <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-white leading-[1.08] mb-6 text-balance">
+                AI commit message generator for{' '}
+                <span className="text-brand whitespace-nowrap">JetBrains IDEs</span>
               </h1>
             </m.div>
 
             <m.p
-              className="text-base sm:text-lg text-gray-400 mb-10 max-w-lg leading-relaxed"
+              className="text-base sm:text-lg text-gray-400 mb-10 max-w-lg leading-relaxed text-pretty"
               {...(canAnimate ? {
                 initial: { opacity: 0, y: 16 },
                 animate: { opacity: 1, y: 0 },

--- a/components/landing/ProductShowcase.tsx
+++ b/components/landing/ProductShowcase.tsx
@@ -70,10 +70,10 @@ export const ProductShowcase = () => {
             viewport: { once: true }
           } : {})}
         >
-          <h2 className="text-3xl md:text-5xl lg:text-6xl font-bold mb-4 text-white tracking-tight">
+          <h2 className="text-3xl md:text-5xl lg:text-6xl font-bold mb-4 text-white tracking-tight text-balance">
             Built into your JetBrains workflow
           </h2>
-          <p className="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto">
+          <p className="text-lg md:text-xl text-gray-400 max-w-3xl mx-auto text-pretty">
             Generate precise commit messages without leaving your editor.
             Works wherever you commit — VCS panel, terminal, or Git integration.
           </p>
@@ -97,7 +97,7 @@ export const ProductShowcase = () => {
                 }}
                 onMouseEnter={() => setIsPaused(true)}
                 onMouseLeave={() => setIsPaused(false)}
-                className={`w-full text-left p-5 rounded-2xl border transition-all duration-300 group ${
+                className={`w-full text-left p-5 rounded-2xl border transition duration-300 group ${
                   activeIndex === index
                     ? 'bg-white/10 border-brand/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
                     : 'bg-white/5 border-white/10 hover:bg-white/8 hover:border-white/20'
@@ -112,7 +112,7 @@ export const ProductShowcase = () => {
                   : {})}
               >
                 <div className="flex items-start gap-4">
-                  <div className={`p-2.5 rounded-xl transition-all duration-300 ${
+                  <div className={`p-2.5 rounded-xl transition duration-300 ${
                     activeIndex === index
                       ? 'bg-brand/20 border border-brand/30'
                       : 'bg-white/10 border border-white/10 group-hover:bg-white/15'
@@ -246,7 +246,7 @@ export const ProductShowcase = () => {
                 id={`showcase-tab-mobile-${index}`}
                 tabIndex={activeIndex === index ? 0 : -1}
                 onClick={() => setActiveIndex(index)}
-                className={`shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-full border transition-all duration-300 ${
+                className={`shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-full border transition duration-300 ${
                   activeIndex === index
                     ? 'bg-brand/20 border-brand/50 text-white'
                     : 'bg-white/5 border-white/10 text-gray-300'

--- a/components/landing/Reviews.tsx
+++ b/components/landing/Reviews.tsx
@@ -61,10 +61,10 @@ export const Reviews = () => {
               <p className="text-xs font-mono uppercase tracking-[0.28em] text-brand/70">
                 Customer feedback
               </p>
-              <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight mt-3">
+              <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight mt-3 text-balance">
                 Feedback from AICommit users
               </h2>
-              <p className="text-gray-400 mt-3 text-sm md:text-base max-w-xl leading-relaxed">
+              <p className="text-gray-400 mt-3 text-sm md:text-base max-w-xl leading-relaxed text-pretty">
                 <AnimatedCounter
                   value={DOWNLOAD_COUNT}
                   format={formatDownloadsText}
@@ -103,7 +103,7 @@ export const Reviews = () => {
                     />
                   </div>
                   <span className="relative flex h-1.5 w-1.5 mb-0.5">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-brand opacity-60 [animation-duration:3s]" />
+                    <span className="animate-ping motion-reduce:hidden absolute inline-flex h-full w-full rounded-full bg-brand opacity-60 [animation-duration:3s]" />
                     <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-brand" />
                   </span>
                 </div>
@@ -124,8 +124,7 @@ export const Reviews = () => {
                 transition: { ...springBase, delay: index * 0.07 },
                 viewport: { once: true },
               } : {})}
-              className="p-6 rounded-2xl bg-white/4 border border-white/10
-                         shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+              className="surface-card p-6"
             >
               {/* Stars */}
               <div className="flex gap-0.5 mb-4">

--- a/components/landing/VideoSection.tsx
+++ b/components/landing/VideoSection.tsx
@@ -49,10 +49,10 @@ export const VideoSection = () => {
             viewport: { once: true },
           } : {})}
         >
-          <h2 className="text-2xl md:text-3xl font-bold text-white tracking-tight">
+          <h2 className="text-2xl md:text-3xl font-bold text-white tracking-tight text-balance">
             Watch AICommit in action
           </h2>
-          <p className="text-gray-400 mt-2 text-sm">
+          <p className="text-gray-400 mt-2 text-sm text-pretty">
             A quick walkthrough from staged files to a generated commit message inside a JetBrains IDE.
           </p>
         </m.div>
@@ -93,7 +93,8 @@ export const VideoSection = () => {
                   onClick={handlePlayVideo}
                   aria-label="Play demo video"
                 >
-                  <Play className="w-8 h-8 text-black fill-black" />
+                  {/* nudged right ~2px so the triangle sits at the optical centre */}
+                  <Play className="w-8 h-8 text-black fill-black translate-x-[2px]" />
                 </m.button>
               </div>
             )}

--- a/components/notfound/GitTerminal.tsx
+++ b/components/notfound/GitTerminal.tsx
@@ -99,7 +99,7 @@ function gitLogLines(): ReactNode[] {
 // RecoveryChips is rendered inline in the scrollback; clicks route through the shared runner.
 let chipRun: ((cmd: string) => void) | null = null;
 function RecoveryChips() {
-  const chip = 'inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-[13px] transition-all hover:-translate-y-px';
+  const chip = 'inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-[13px] transition hover:-translate-y-px';
   return (
     <div className="my-2 flex flex-wrap gap-2.5">
       <button type="button" className={`${chip} border-brand/40 bg-brand/8 text-gray-100 hover:border-brand hover:bg-brand/16`} onClick={() => chipRun?.('cd ~')}>

--- a/components/ui/CommitPreview.tsx
+++ b/components/ui/CommitPreview.tsx
@@ -72,17 +72,17 @@ export const CommitPreview = () => {
         </div>
         <div className="ml-auto flex items-center gap-1.5">
           <span className="relative flex h-1.5 w-1.5">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-brand opacity-50 [animation-duration:2s]" />
+            <span className="animate-ping motion-reduce:hidden absolute inline-flex h-full w-full rounded-full bg-brand opacity-50 [animation-duration:2s]" />
             <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-brand/70" />
           </span>
-          <span className="font-mono text-[10px] text-gray-600">generating</span>
+          <span className="font-mono text-[10px] text-gray-400">generating</span>
         </div>
       </div>
 
       {/* Commit message input area — mimics IDE message field */}
       <div className="px-3 py-2.5">
         <div className="flex items-center justify-between mb-1.5">
-          <span className="text-[10px] text-gray-500 font-medium">Commit Message</span>
+          <span className="text-[10px] text-gray-400 font-medium">Commit Message</span>
           <div className="flex items-center gap-1 text-brand/60">
             <Sparkles className="w-3 h-3" />
             <span className="text-[10px]">AI</span>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -33,10 +33,10 @@ export default function NotFound() {
         <meta name="theme-color" content="#21252f" />
       </Head>
 
-      <div className="relative min-h-screen overflow-hidden text-white">
+      <div className="relative min-h-dvh overflow-hidden text-white">
         <Background />
 
-        <main className="relative z-20 flex min-h-screen flex-col items-center justify-center px-4 py-20">
+        <main className="relative z-20 flex min-h-dvh flex-col items-center justify-center px-4 py-20">
           <h1 className="mb-2 font-mono text-2xl font-bold text-brand md:text-3xl">404</h1>
           <p className="mb-8 font-mono text-sm text-gray-400">commit not found in this tree</p>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,7 +75,7 @@ const LandingPage = () => {
         />
       </Head>
 
-      <div className="relative min-h-screen text-white overflow-hidden">
+      <div className="relative min-h-dvh text-white overflow-hidden">
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-100 focus:px-4 focus:py-2 focus:bg-brand focus:text-black focus:font-semibold focus:rounded-lg"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,6 +50,12 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 :root {
   --foreground-rgb: 255, 255, 255;
   --background-start-rgb: 33, 37, 47;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,6 +3,12 @@
 @theme {
   --color-brand: #ded14f;
 
+  /* Semantic surface/line tokens — single source of truth for the repeated
+     card treatment. Use `bg-raised` / `border-line` directly, or the
+     `.surface-card` shorthand below. */
+  --color-line: rgba(255, 255, 255, 0.1);
+  --color-raised: rgba(255, 255, 255, 0.04);
+
   --font-sans:
     var(--font-zed-sans), system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
     Arial, sans-serif;
@@ -26,6 +32,17 @@
   ::backdrop,
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
+  }
+}
+
+@layer components {
+  /* Repeated card treatment: a raised translucent surface with a hairline
+     border and a top inner highlight. Tokens above are the source of truth. */
+  .surface-card {
+    border-radius: 1rem; /* matches rounded-2xl */
+    border: 1px solid var(--color-line);
+    background-color: var(--color-raised);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
   }
 }
 
@@ -82,4 +99,16 @@ body {
 .btn-shimmer:hover::after {
   transform: translateX(120%);
   transition: transform 0.5s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Honour the user's reduced-motion preference for always-on / hover CSS
+   animations that aren't gated in JS (the blinking cursor and CTA shimmer). */
+@media (prefers-reduced-motion: reduce) {
+  .cursor-blink {
+    animation: none;
+  }
+
+  .btn-shimmer::after {
+    display: none;
+  }
 }


### PR DESCRIPTION
Applies a design-vocabulary audit of the landing page. No behavioural/content changes — accessibility fixes, interaction/type polish, and a small token refactor.

### A — accessibility fixes
- **Contrast**: lift sub-AA text to `gray-400` (~6:1 on `#21252f`). `gray-500` (~3.2:1) and `gray-600` (~2:1) failed WCAG AA — `CommitPreview`, `Features`.
- **Reduced motion**: gate always-on `animate-ping` with `motion-reduce:hidden`; disable `.cursor-blink` and the `.btn-shimmer` sweep under `prefers-reduced-motion`.
- **Touch target**: mobile menu toggle hit area → 44px.
- **Focus trap**: mobile drawer now traps + cycles focus, autofocuses on open, and returns focus to the toggle on close.

### B — interaction & type polish
- Replace fragile manual `<br>` with `text-balance` on headings; `text-pretty` on body copy (widow/orphan control).
- `min-h-screen` → `min-h-dvh` (mobile browser-chrome overflow).
- `transition-all` → `transition` (don't animate layout properties).
- Optical-centre nudge on the play triangle.
- Enter (ease-out) vs exit (ease-in) asymmetry on the drawer.

### C — tokens & dedup
- Add semantic tokens `--color-line` / `--color-raised` + a `.surface-card` shorthand; collapse the duplicated card recipe in `Reviews` / `CompatibilityFaq`.

### Verification
`tsc` clean · `eslint` 0 errors · `next build` ok · SEO tests 6/6.

13 files changed, +109 / −47.